### PR TITLE
Fix search attribute mapping for vegan and vegetarian filters

### DIFF
--- a/src/Cli.hs
+++ b/src/Cli.hs
@@ -163,8 +163,8 @@ searchAttributeParser =
     <$> sequenceA
       [ flag [] [Organic] (long "organic" <> help "Filter only organic products")
       , flag [] [Regional] (long "regional" <> help "Filter only regional products")
-      , flag [] [Regional] (long "vegan" <> help "Filter only vegan products")
-      , flag [] [Regional] (long "vegetarian" <> help "Filter only vegetarian products")
+      , flag [] [Vegan] (long "vegan" <> help "Filter only vegan products")
+      , flag [] [Vegetarian] (long "vegetarian" <> help "Filter only vegetarian products")
       ]
 
 searchParser :: Parser Command


### PR DESCRIPTION
## Summary

Fixes a bug in `src/Cli.hs` where the `--vegan` and `--vegetarian` command-line flags were incorrectly mapped to the `[Regional]` search attribute instead of `[Vegan]` and `[Vegetarian]`.

## Problem

In the `searchAttributeParser` function, both vegan and vegetarian flags were using `[Regional]`:

```haskell
, flag [] [Regional] (long "vegan" <> help "Filter only vegan products")
, flag [] [Regional] (long "vegetarian" <> help "Filter only vegetarian products")
```

This meant that using `--vegan` or `--vegetarian` would incorrectly filter for regional products instead.

## Solution

Use the correct `SearchAttribute` constructors:

```haskell
, flag [] [Vegan] (long "vegan" <> help "Filter only vegan products")
, flag [] [Vegetarian] (long "vegetarian" <> help "Filter only vegetarian products")
```

## Impact

- `--vegan` now correctly filters for vegan products
- `--vegetarian` now correctly filters for vegetarian products
- `--regional` continues to work as before

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>